### PR TITLE
refactor: extract build_year_chart_point for modular chart data gener…

### DIFF
--- a/backend/app/services/amortisation.py
+++ b/backend/app/services/amortisation.py
@@ -1,14 +1,107 @@
 """
 Amortisation service.
 
-Orchestrates the amortisation engine and builds chart data
-with cumulative interest, property appreciation, and offset projections.
+Provides three functions:
+- build_amortisation_schedule: raw schedule only (used by cashflow service)
+- build_year_chart_point: single year's chart data point
+- build_schedule_result: schedule + chart data (used by amortisation endpoint)
 """
 
 from app.engine.amortisation import generate_schedule
-from app.models.amortisation import ScheduleResult, YearChartPoint
+from app.models.amortisation import AmortisationSchedule, ScheduleResult, YearChartPoint
 from app.models.loan import LoanConfig
 from app.models.property import Property
+
+
+def build_amortisation_schedule(
+    property: Property,
+    loan: LoanConfig,
+) -> AmortisationSchedule:
+    """
+    Generate a raw amortisation schedule without chart data.
+
+    Derives loan_amount from property and loan config. Calls the engine
+    to produce the period-by-period schedule.
+
+    Args:
+        property: Property details with purchase price
+        loan: Mortgage loan configuration (deposit, rate, term, offset, etc.)
+
+    Returns:
+        AmortisationSchedule with per-period rows and summary stats
+    """
+    loan_amount = max(property.purchase_price - loan.deposit, 0.0)
+
+    return generate_schedule(
+        principal=loan_amount,
+        annual_rate=loan.annual_rate,
+        loan_term_years=loan.loan_term_years,
+        frequency=loan.frequency,
+        offset_balance=loan.offset_balance,
+        extra_repayment=loan.extra_repayment,
+        rate_changes=loan.rate_changes or None,
+        offset_contribution=loan.offset_contribution,
+    )
+
+
+def build_year_chart_point(
+    year: int,
+    property: Property,
+    loan: LoanConfig,
+    schedule: AmortisationSchedule,
+) -> YearChartPoint:
+    """
+    Build a single year's chart data point.
+
+    Calculates property value, loan balance, cumulative interest,
+    equity, and projected offset for the given year.
+
+    Args:
+        year: Projection year (0 = purchase year)
+        property: Property details with purchase price and annual appreciation
+        loan: Loan configuration (deposit, offset balance/contribution, frequency)
+        schedule: Full amortisation schedule to read balances from
+
+    Returns:
+        YearChartPoint for the given year
+    """
+    loan_amount = max(property.purchase_price - loan.deposit, 0.0)
+    ppy = schedule.periods_per_year
+
+    if year == 0:
+        return YearChartPoint(
+            year=0,
+            balance=loan_amount,
+            total_interest=0.0,
+            property_value=property.purchase_price,
+            equity=round(loan.deposit, 2),
+            offset_balance=round(loan.offset_balance, 2),
+        )
+
+    property_value = property.purchase_price * (1 + property.annual_appreciation) ** year
+
+    if schedule.rows:
+        idx = min(year * ppy - 1, len(schedule.rows) - 1)
+        row = schedule.rows[idx]
+        balance = row.closing_balance
+        cumulative_interest = sum(r.interest for r in schedule.rows[: idx + 1])
+    else:
+        balance = 0.0
+        cumulative_interest = 0.0
+
+    equity = property_value - balance
+
+    periods_elapsed = year * ppy
+    projected_offset = loan.offset_balance + loan.offset_contribution * max(periods_elapsed - 1, 0)
+
+    return YearChartPoint(
+        year=year,
+        balance=round(balance, 2),
+        total_interest=round(cumulative_interest, 2),
+        property_value=round(property_value, 2),
+        equity=round(equity, 2),
+        offset_balance=round(projected_offset, 2),
+    )
 
 
 def build_schedule_result(
@@ -18,9 +111,8 @@ def build_schedule_result(
     """
     Generate a full amortisation schedule with chart data.
 
-    Derives loan_amount and LVR from property and loan config. Calls the
-    engine to produce the raw schedule, then builds yearly chart points
-    with cumulative interest, appreciation, and offset projections.
+    Delegates to build_amortisation_schedule for the raw schedule,
+    then builds yearly chart points via build_year_chart_point.
 
     Args:
         property: Property details with purchase price and annual appreciation
@@ -32,58 +124,12 @@ def build_schedule_result(
     loan_amount = max(property.purchase_price - loan.deposit, 0.0)
     lvr = loan_amount / property.purchase_price if property.purchase_price > 0 else 0.0
 
-    schedule = generate_schedule(
-        principal=loan_amount,
-        annual_rate=loan.annual_rate,
-        loan_term_years=loan.loan_term_years,
-        frequency=loan.frequency,
-        offset_balance=loan.offset_balance,
-        extra_repayment=loan.extra_repayment,
-        rate_changes=loan.rate_changes or None,
-        offset_contribution=loan.offset_contribution,
-    )
+    schedule = build_amortisation_schedule(property=property, loan=loan)
 
-    # Build yearly chart data with appreciation
-    ppy = loan.frequency.periods_per_year
-    chart_data: list[YearChartPoint] = [
-        YearChartPoint(
-            year=0,
-            balance=loan_amount,
-            total_interest=0.0,
-            property_value=property.purchase_price,
-            equity=round(loan.deposit, 2),
-            offset_balance=round(loan.offset_balance, 2),
-        )
+    chart_data = [
+        build_year_chart_point(year, property, loan, schedule)
+        for year in range(loan.loan_term_years + 1)
     ]
-
-    for year in range(1, loan.loan_term_years + 1):
-        property_value = property.purchase_price * (1 + property.annual_appreciation) ** year
-
-        if schedule.rows:
-            idx = min(year * ppy - 1, len(schedule.rows) - 1)
-            row = schedule.rows[idx]
-            balance = row.closing_balance
-            cumulative_interest = sum(r.interest for r in schedule.rows[: idx + 1])
-        else:
-            balance = 0.0
-            cumulative_interest = 0.0
-
-        equity = property_value - balance
-
-        # Offset keeps growing even after loan is paid off
-        periods_elapsed = year * ppy
-        projected_offset = loan.offset_balance + loan.offset_contribution * max(periods_elapsed - 1, 0)
-
-        chart_data.append(
-            YearChartPoint(
-                year=year,
-                balance=round(balance, 2),
-                total_interest=round(cumulative_interest, 2),
-                property_value=round(property_value, 2),
-                equity=round(equity, 2),
-                offset_balance=round(projected_offset, 2),
-            )
-        )
 
     return ScheduleResult(
         schedule=schedule,

--- a/backend/app/services/cashflow.py
+++ b/backend/app/services/cashflow.py
@@ -20,7 +20,7 @@ from app.models.financial import FinancialYear
 from app.models.loan import LoanConfig
 from app.models.property import Property, OngoingCostsConfig, OngoingCostProjection, RentvestConfig, YearCost, UpfrontCosts
 from app.models.tax import TaxProfile
-from app.services.amortisation import build_schedule_result
+from app.services.amortisation import build_amortisation_schedule
 from app.services.ongoing_costs import build_ongoing_cost_projection
 from app.services.tax_deductions import build_tax_deduction_summary
 from app.services.upfront_costs import build_upfront_cost_estimate
@@ -88,7 +88,7 @@ def _build_projection_inputs(
         Tuple of (resolved upfront costs, amortisation schedule, ongoing cost projection)
     """
     upfront_costs = build_upfront_cost_estimate(property=property, loan=loan)
-    schedule = build_schedule_result(property=property, loan=loan).schedule
+    schedule = build_amortisation_schedule(property=property, loan=loan)
     cost_projection = build_ongoing_cost_projection(property=property, ongoing_costs=ongoing_costs, projection_years=projection_years)
     return upfront_costs, schedule, cost_projection
 


### PR DESCRIPTION
## Summary

  Split amortisation service into three focused functions for better modularity.

  ### Changes
  - **`build_amortisation_schedule(property, loan)`** — raw schedule only, no chart data (used by cashflow service)
  - **`build_year_chart_point(year, property, loan, schedule)`** — single year's chart data point (standalone, reusable)
  - **`build_schedule_result(property, loan)`** — delegates to both, assembles full result (used by amortisation endpoint)
  - **Cashflow service** — calls `build_amortisation_schedule` directly, skipping chart generation

  No behaviour change for any endpoint. All 893 tests passing.

  Closes #38