### PR TITLE
feat: support per-cost capitalisation of borrowing costs onto loan pr…

### DIFF
--- a/backend/app/models/loan.py
+++ b/backend/app/models/loan.py
@@ -61,15 +61,51 @@ class BorrowingCosts:
 
     Fields default to None (auto-estimated by upfront costs service).
     Set to 0.0 to explicitly waive (e.g. LMI exempt). Set to a value to override.
+    Each cost has a capitalise flag — True adds it to the loan principal,
+    False pays it as cash at settlement.
 
     Attributes:
         lmi: Lenders Mortgage Insurance (None = auto-estimate)
         mortgage_registration_fee: Mortgage registration fee (None = auto-estimate)
         loan_establishment_fee: Loan establishment/application fee (None = auto-estimate)
+        capitalise_lmi: Whether to add LMI to loan principal (default True)
+        capitalise_mortgage_registration_fee: Whether to add mortgage registration to principal (default True)
+        capitalise_loan_establishment_fee: Whether to add loan establishment to principal (default True)
     """
     lmi: Optional[float] = None
     mortgage_registration_fee: Optional[float] = None
     loan_establishment_fee: Optional[float] = None
+    capitalise_lmi: bool = True
+    capitalise_mortgage_registration_fee: bool = True
+    capitalise_loan_establishment_fee: bool = True
+
+    @property
+    def total_capitalised(self) -> float:
+        """
+        Amount added to loan principal.
+
+        Returns:
+            Sum of borrowing costs where capitalise flag is True
+        """
+        return (
+            ((self.lmi or 0.0) if self.capitalise_lmi else 0.0) +
+            ((self.mortgage_registration_fee or 0.0) if self.capitalise_mortgage_registration_fee else 0.0) +
+            ((self.loan_establishment_fee or 0.0) if self.capitalise_loan_establishment_fee else 0.0)
+        )
+
+    @property
+    def total_upfront(self) -> float:
+        """
+        Amount paid as cash at settlement.
+
+        Returns:
+            Sum of borrowing costs where capitalise flag is False
+        """
+        return (
+            ((self.lmi or 0.0) if not self.capitalise_lmi else 0.0) +
+            ((self.mortgage_registration_fee or 0.0) if not self.capitalise_mortgage_registration_fee else 0.0) +
+            ((self.loan_establishment_fee or 0.0) if not self.capitalise_loan_establishment_fee else 0.0)
+        )
 
     @property
     def total(self) -> float:

--- a/backend/app/models/property.py
+++ b/backend/app/models/property.py
@@ -70,12 +70,22 @@ class UpfrontCosts:
     borrowing_costs: BorrowingCosts = field(default_factory=BorrowingCosts)
 
     @property
-    def total(self) -> float:
+    def total_cash_at_settlement(self) -> float:
         """
-        Total cash out at settlement.
+        Total cash required at settlement (excludes capitalised costs).
 
         Returns:
-            Sum of purchase costs and borrowing costs
+            Purchase costs + non-capitalised borrowing costs
+        """
+        return self.purchase_costs.total + self.borrowing_costs.total_upfront
+
+    @property
+    def total(self) -> float:
+        """
+        Total of all upfront costs (capitalised and non-capitalised).
+
+        Returns:
+            Sum of all purchase costs and all borrowing costs
         """
         return self.purchase_costs.total + self.borrowing_costs.total
 

--- a/backend/app/routers/cashflow.py
+++ b/backend/app/routers/cashflow.py
@@ -104,6 +104,9 @@ def _build_loan(req: CashFlowPPORRequest) -> LoanConfig:
             lmi=req.loan.borrowing_costs.lmi,
             mortgage_registration_fee=req.loan.borrowing_costs.mortgage_registration_fee,
             loan_establishment_fee=req.loan.borrowing_costs.loan_establishment_fee,
+            capitalise_lmi=req.loan.borrowing_costs.capitalise_lmi,
+            capitalise_mortgage_registration_fee=req.loan.borrowing_costs.capitalise_mortgage_registration_fee,
+            capitalise_loan_establishment_fee=req.loan.borrowing_costs.capitalise_loan_establishment_fee,
         ),
     )
 

--- a/backend/app/schemas/cashflow.py
+++ b/backend/app/schemas/cashflow.py
@@ -72,6 +72,9 @@ class BorrowingCostsRequest(BaseModel):
     lmi: Optional[float] = Field(default=None, ge=0, description="Override LMI (None = auto-estimate)")
     mortgage_registration_fee: Optional[float] = Field(default=None, ge=0, description="Override mortgage registration (None = auto-estimate)")
     loan_establishment_fee: Optional[float] = Field(default=None, ge=0, description="Override loan establishment (None = auto-estimate)")
+    capitalise_lmi: bool = Field(default=True, description="Add LMI to loan principal")
+    capitalise_mortgage_registration_fee: bool = Field(default=True, description="Add mortgage registration to loan principal")
+    capitalise_loan_establishment_fee: bool = Field(default=True, description="Add loan establishment to loan principal")
 
 
 class RentalConfigRequest(BaseModel):

--- a/backend/app/services/amortisation.py
+++ b/backend/app/services/amortisation.py
@@ -31,6 +31,7 @@ def build_amortisation_schedule(
         AmortisationSchedule with per-period rows and summary stats
     """
     loan_amount = max(property.purchase_price - loan.deposit, 0.0)
+    loan_amount += loan.borrowing_costs.total_capitalised
 
     return generate_schedule(
         principal=loan_amount,
@@ -49,6 +50,7 @@ def build_year_chart_point(
     property: Property,
     loan: LoanConfig,
     schedule: AmortisationSchedule,
+    loan_amount: float,
 ) -> YearChartPoint:
     """
     Build a single year's chart data point.
@@ -61,11 +63,11 @@ def build_year_chart_point(
         property: Property details with purchase price and annual appreciation
         loan: Loan configuration (deposit, offset balance/contribution, frequency)
         schedule: Full amortisation schedule to read balances from
+        loan_amount: Pre-calculated loan principal (including capitalised costs)
 
     Returns:
         YearChartPoint for the given year
     """
-    loan_amount = max(property.purchase_price - loan.deposit, 0.0)
     ppy = schedule.periods_per_year
 
     if year == 0:
@@ -122,12 +124,13 @@ def build_schedule_result(
         ScheduleResult with per-period schedule, summary stats, and yearly chart data
     """
     loan_amount = max(property.purchase_price - loan.deposit, 0.0)
+    loan_amount += loan.borrowing_costs.total_capitalised
     lvr = loan_amount / property.purchase_price if property.purchase_price > 0 else 0.0
 
     schedule = build_amortisation_schedule(property=property, loan=loan)
 
     chart_data = [
-        build_year_chart_point(year, property, loan, schedule)
+        build_year_chart_point(year, property, loan, schedule, loan_amount)
         for year in range(loan.loan_term_years + 1)
     ]
 

--- a/backend/app/services/cashflow.py
+++ b/backend/app/services/cashflow.py
@@ -248,7 +248,7 @@ def build_ppor_cashflow(
     )
 
     # Build list of CashFlowYear models for each year
-    cumulative_cash_position = -upfront_costs.total
+    cumulative_cash_position = -upfront_costs.total_cash_at_settlement
     cashflow_years = []
     for year in range(projection_years):
         grown_profile = _grow_tax_profile(tax_profile, year)
@@ -310,7 +310,7 @@ def build_rentvest_cashflow(
     )
 
     # Build list of CashFlowYear models for each year
-    cumulative_cash_position = -upfront_costs.total
+    cumulative_cash_position = -upfront_costs.total_cash_at_settlement
     cashflow_years = []
     for year in range(projection_years):
         year_rows = _get_year_rows(schedule, year)

--- a/backend/app/tests/services/test_cashflow.py
+++ b/backend/app/tests/services/test_cashflow.py
@@ -794,7 +794,7 @@ class TestBuildPporCashflow:
 
     def test_cumulative_is_running_total(self):
         result = self._build(projection_years=3)
-        expected = -result.upfront_costs.total
+        expected = -result.upfront_costs.total_cash_at_settlement
         for y in result.years:
             expected += y.net_position
             assert y.cumulative_position == pytest.approx(expected, abs=1)
@@ -1018,7 +1018,7 @@ class TestBuildRentvestCashflow:
 
     def test_cumulative_is_running_total(self):
         result = self._build(projection_years=3)
-        expected = -result.upfront_costs.total
+        expected = -result.upfront_costs.total_cash_at_settlement
         for y in result.years:
             expected += y.net_position
             assert y.cumulative_position == pytest.approx(expected, abs=1)


### PR DESCRIPTION
## Summary

  Support per-cost capitalisation of borrowing costs onto the loan principal, reflecting typical Australian lending practice where LMI and other loan costs
  are added to the loan rather than paid as cash at settlement.

  ### Changes

  **Model (`BorrowingCosts`):**
  - Added `capitalise_lmi`, `capitalise_mortgage_registration_fee`, `capitalise_loan_establishment_fee` flags (all default `True`)
  - `total_capitalised` property — sum of costs added to loan principal
  - `total_upfront` property — sum of costs paid as cash at settlement
  - Fixed operator precedence bug in ternary expressions

  **Model (`UpfrontCosts`):**
  - Added `total_cash_at_settlement` — purchase costs + non-capitalised borrowing costs only
  - `total` unchanged — all costs regardless of capitalisation

  **Amortisation service:**
  - `build_amortisation_schedule` adds `total_capitalised` to loan principal
  - `build_schedule_result` and `build_year_chart_point` reflect adjusted principal and LVR
  - `loan_amount` calculated once and passed to chart point builder (avoids per-year recalculation)

  **Cashflow service:**
  - Year 0 cumulative position offset by `total_cash_at_settlement` (not total)

  **Schema/Router:**
  - `BorrowingCostsRequest` accepts capitalise flags
  - Router maps them through to domain model

  ### Example
  $500k purchase, $25k deposit, $21k LMI (capitalised):
  - **Principal:** $475k + $21k = $496k (higher repayments, more interest)
  - **Cash at settlement:** purchase costs only (no $21k LMI outflow)
  - **Not capitalised:** $475k principal, $21k cash at settlement

  All 893 tests passing.

  Closes #35