### PR TITLE
feat(models): introduce Person model to own tax profile on Mortgage a…

### DIFF
--- a/backend/app/models/mortgage.py
+++ b/backend/app/models/mortgage.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 from app.models.loan import Loan
+from app.models.person import Person
 from app.models.property import Property, OngoingCostsConfig, RentvestConfig
-from app.models.tax import TaxProfile
 
 
 @dataclass
@@ -15,21 +15,21 @@ class Mortgage:
     """
     Aggregate root linking all domain models for a single property scenario.
 
-    Bundles property, loan, tax, and ongoing cost configuration into one
+    Bundles property, loan, person, and ongoing cost configuration into one
     object that services accept as a single parameter. Eliminates the need
     to thread multiple models through service layers independently.
 
     Attributes:
         property: Property details (purchase price, costs, appreciation, rental, depreciation)
         loan: Loan aggregate (config + amortisation schedule)
-        tax_profile: Taxpayer income configuration (None for amortisation-only use)
+        person: Person owning this mortgage (None for amortisation-only use)
         ongoing_costs: Base ongoing cost rates and growth rate (None for amortisation-only use)
         rentvest: Tenant rental configuration (None for PPOR)
         projection_years: Number of years to project
     """
     property: Property
     loan: Loan
-    tax_profile: Optional[TaxProfile] = None
+    person: Optional[Person] = None
     ongoing_costs: Optional[OngoingCostsConfig] = None
     rentvest: Optional[RentvestConfig] = None
     projection_years: int = 30

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -1,0 +1,21 @@
+"""
+Person domain model — taxpayer identity and financial profile.
+"""
+
+from dataclasses import dataclass
+
+from app.models.tax import TaxProfile
+
+
+@dataclass
+class Person:
+    """
+    Represents the individual behind a mortgage scenario.
+
+    Owns personal financial attributes that are independent of any
+    specific property or loan.
+
+    Attributes:
+        tax_profile: Taxpayer income configuration for tax calculations.
+    """
+    tax_profile: TaxProfile

--- a/backend/app/routers/amortisation.py
+++ b/backend/app/routers/amortisation.py
@@ -57,7 +57,7 @@ def get_schedule(req: ScheduleRequest) -> ScheduleResponse:
     mortgage = Mortgage(
         property=property,
         loan=build_loan(property, loan_config),
-        tax_profile=None,
+        person=None,
         ongoing_costs=None,
     )
 

--- a/backend/app/routers/cashflow.py
+++ b/backend/app/routers/cashflow.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter
 from app.models.deductions import DepreciableBuilding, DepreciableAsset
 from app.models.loan import RateChange, LoanConfig, BorrowingCosts
 from app.models.mortgage import Mortgage
+from app.models.person import Person
 from app.models.property import Property, PurchaseCosts, OngoingCostsConfig, RentvestConfig, RentalConfig
 from app.models.tax import TaxProfile
 from app.schemas.cashflow import (
@@ -207,7 +208,7 @@ def get_ppor_cashflow(req: CashFlowPPORRequest) -> CashFlowPPORResponse:
     mortgage = Mortgage(
         property=property,
         loan=build_loan(property, _build_loan_config(req)),
-        tax_profile=_build_tax_profile(req),
+        person=Person(tax_profile=_build_tax_profile(req)),
         ongoing_costs=_build_ongoing_costs(req),
         projection_years=req.projection_years,
     )
@@ -237,7 +238,7 @@ def get_rentvest_cashflow(req: CashFlowRentvestRequest) -> CashFlowRentvestRespo
     mortgage = Mortgage(
         property=property,
         loan=build_loan(property, _build_loan_config(req)),
-        tax_profile=_build_tax_profile(req),
+        person=Person(tax_profile=_build_tax_profile(req)),
         ongoing_costs=_build_ongoing_costs(req),
         rentvest=RentvestConfig(
             weekly_rent_paid=req.weekly_rent_paid,

--- a/backend/app/services/cashflow.py
+++ b/backend/app/services/cashflow.py
@@ -19,6 +19,7 @@ from app.models.cashflow import CashFlowYear, CashFlowSummary, CashFlowPPORResul
 from app.models.deductions import PropertyTaxDeductionSummary
 from app.models.financial import FinancialYear
 from app.models.mortgage import Mortgage
+from app.models.person import Person
 from app.models.property import OngoingCostProjection, RentvestConfig, YearCost, UpfrontCosts
 from app.models.tax import TaxProfile
 from app.services.ongoing_costs import build_ongoing_cost_projection
@@ -197,7 +198,7 @@ def build_ppor_cashflow(mortgage: Mortgage) -> CashFlowPPORResult:
     Owner lives in the property. No rental income, no tax deductions, no CGT.
 
     Growth rates are sourced from domain models:
-    - Income growth from mortgage.tax_profile.income_growth_rate
+    - Income growth from mortgage.person.tax_profile.income_growth_rate
     - Property appreciation from mortgage.property.annual_appreciation
     - Cost inflation from mortgage.ongoing_costs.annual_cost_growth_rate
 
@@ -215,7 +216,7 @@ def build_ppor_cashflow(mortgage: Mortgage) -> CashFlowPPORResult:
     cumulative_cash_position = -upfront_costs.total_cash_at_settlement
     cashflow_years = []
     for year in range(mortgage.projection_years):
-        grown_profile = _grow_tax_profile(mortgage.tax_profile, year)
+        grown_profile = _grow_tax_profile(mortgage.person.tax_profile, year)
 
         cashflow_year = _calculate_cashflow_year(
             year=year,
@@ -243,7 +244,7 @@ def build_rentvest_cashflow(mortgage: Mortgage) -> CashFlowRentvestResult:
     Includes rental income, tax deductions, tax saving, and CGT at sale.
 
     Growth rates are sourced from domain models:
-    - Income growth from mortgage.tax_profile.income_growth_rate
+    - Income growth from mortgage.person.tax_profile.income_growth_rate
     - Property appreciation from mortgage.property.annual_appreciation
     - Rental income growth from mortgage.property.rental.annual_growth_rate
     - Rent paid growth from mortgage.rentvest.annual_rent_paid_growth
@@ -271,10 +272,10 @@ def build_rentvest_cashflow(mortgage: Mortgage) -> CashFlowRentvestResult:
         financial_year = FinancialYear(fy_year)
 
         # Grow tax profile for this year
-        grown_profile = _grow_tax_profile(mortgage.tax_profile, year)
+        grown_profile = _grow_tax_profile(mortgage.person.tax_profile, year)
 
         # Calculate tax deductions for this year
-        year_mortgage = replace(mortgage, tax_profile=grown_profile)
+        year_mortgage = replace(mortgage, person=Person(tax_profile=grown_profile))
         tax_deduction = build_tax_deduction_summary(
             mortgage=year_mortgage,
             year=year,
@@ -299,7 +300,7 @@ def build_rentvest_cashflow(mortgage: Mortgage) -> CashFlowRentvestResult:
         mortgage.projection_years, mortgage.property.purchase_price, mortgage.property.annual_appreciation
     )
     sale_date = mortgage.property.purchase_date + timedelta(days=365 * mortgage.projection_years)
-    grown_profile = _grow_tax_profile(mortgage.tax_profile, mortgage.projection_years)
+    grown_profile = _grow_tax_profile(mortgage.person.tax_profile, mortgage.projection_years)
     cgt = calculate_cgt(
         property=mortgage.property,
         sale_price=sale_price,

--- a/backend/app/services/tax_deductions.py
+++ b/backend/app/services/tax_deductions.py
@@ -189,7 +189,7 @@ def build_tax_deduction_summary(
     # Calculate net rental income after deductions and determine if negatively geared
     net_rental_income = rental_income - total_deductions
     is_negatively_geared = net_rental_income < 0
-    tax_saving = calculate_tax_saving(mortgage.tax_profile, net_rental_income)
+    tax_saving = calculate_tax_saving(mortgage.person.tax_profile, net_rental_income)
 
     return PropertyTaxDeductionSummary(
         mortgage_interest=mortgage_interest,

--- a/backend/app/tests/services/test_cashflow.py
+++ b/backend/app/tests/services/test_cashflow.py
@@ -18,6 +18,7 @@ from app.models.cashflow import CashFlowYear
 from app.models.deductions import PropertyTaxDeductionSummary, DepreciableBuilding
 from app.models.loan import LoanConfig, BorrowingCosts, Loan
 from app.models.mortgage import Mortgage
+from app.models.person import Person
 from app.models.property import (
     Property, PurchaseCosts, OngoingCostsConfig, RentvestConfig,
     RentalConfig, YearCost,
@@ -104,7 +105,7 @@ def _make_mortgage(property=None, tax_profile=None, loan=None,
     return Mortgage(
         property=p,
         loan=build_loan(p, lc),
-        tax_profile=tax_profile or _make_tax_profile(),
+        person=Person(tax_profile=tax_profile or _make_tax_profile()),
         ongoing_costs=ongoing_costs or _make_ongoing_costs(),
         rentvest=rentvest,
         projection_years=projection_years,

--- a/backend/app/tests/services/test_tax_deductions.py
+++ b/backend/app/tests/services/test_tax_deductions.py
@@ -18,6 +18,7 @@ from app.models.deductions import DepreciableBuilding, DepreciableAsset, Depreci
 from app.models.financial import FinancialYear
 from app.models.loan import Loan, LoanConfig, BorrowingCosts
 from app.models.mortgage import Mortgage
+from app.models.person import Person
 from app.models.property import YearCost, Property
 from app.models.tax import TaxProfile
 from app.engine.tax import calculate_total_tax
@@ -155,7 +156,7 @@ def _make_mortgage(property=None, loan=None, tax_profile=None) -> Mortgage:
     return Mortgage(
         property=p,
         loan=loan_obj,
-        tax_profile=tax_profile or _make_tax_profile(),
+        person=Person(tax_profile=tax_profile or _make_tax_profile()),
     )
 
 


### PR DESCRIPTION
## Summary
  - Introduced `Person` domain model wrapping `TaxProfile`, establishing person-level ownership of financial attributes
  - Updated `Mortgage` aggregate: `tax_profile` field replaced by `person` field
  - Updated all services, routers, and tests to access tax profile via `mortgage.person.tax_profile`

  ## Test plan
  - [ ] All 981 existing tests pass
  - [ ] API contract unchanged — no frontend impact

  Closes #44