### PR TITLE
fix: include offset contributions in outflows and capitalise auto-est…

### DIFF
--- a/backend/app/models/cashflow.py
+++ b/backend/app/models/cashflow.py
@@ -26,6 +26,7 @@ class CashFlowYear:
         mortgage_interest: Interest portion of mortgage payments
         mortgage_principal: Principal portion of mortgage payments
         property_costs: Ongoing property costs for the year
+        offset_contributions: Cash added to offset account this year
         rent_paid: Annual rent where the investor lives (0 for PPOR)
         rental_income: Annual rental income received (0 for PPOR)
         tax_saving: Tax benefit from deductions (0 for PPOR, negative if positively geared)
@@ -48,6 +49,7 @@ class CashFlowYear:
     mortgage_interest: float
     mortgage_principal: float
     property_costs: float
+    offset_contributions: float
     rent_paid: float
     rental_income: float
     tax_saving: float

--- a/backend/app/routers/_cashflow_mapping.py
+++ b/backend/app/routers/_cashflow_mapping.py
@@ -130,6 +130,7 @@ def map_year_response(year) -> CashFlowYearResponse:
         mortgage_interest=year.mortgage_interest,
         mortgage_principal=year.mortgage_principal,
         property_costs=year.property_costs,
+        offset_contributions=year.offset_contributions,
         rent_paid=year.rent_paid,
         rental_income=year.rental_income,
         tax_saving=year.tax_saving,

--- a/backend/app/routers/amortisation.py
+++ b/backend/app/routers/amortisation.py
@@ -9,7 +9,7 @@ from datetime import date
 
 from fastapi import APIRouter
 
-from app.models.loan import LoanConfig, RateChange
+from app.models.loan import BorrowingCosts, LoanConfig, RateChange
 from app.models.mortgage import Mortgage
 from app.models.property import Property
 from app.schemas.amortisation import (
@@ -51,6 +51,7 @@ def get_schedule(req: ScheduleRequest) -> ScheduleResponse:
         offset_contribution=req.offset_contribution,
         extra_repayment=req.extra_repayment,
         rate_changes=[RateChange(from_period=rc.from_period, annual_rate=rc.annual_rate) for rc in req.rate_changes],
+        borrowing_costs=BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
     )
     mortgage = Mortgage(
         property=property,

--- a/backend/app/routers/ongoing_costs.py
+++ b/backend/app/routers/ongoing_costs.py
@@ -9,7 +9,7 @@ from datetime import date
 
 from fastapi import APIRouter
 
-from app.models.loan import LoanConfig
+from app.models.loan import BorrowingCosts, LoanConfig
 from app.models.mortgage import Mortgage
 from app.models.property import OngoingCostsConfig, Property, RentalConfig
 from app.schemas.ongoing_costs import OngoingCostResponse, OngoingPropertyCostRequest, YearByYearCostResponse
@@ -54,7 +54,12 @@ def get_ongoing_costs(req: OngoingPropertyCostRequest) -> OngoingCostResponse:
         annual_cost_growth_rate=req.annual_cost_growth_rate,
     )
 
-    loan_config = LoanConfig(deposit=0, annual_rate=0.0, loan_term_years=30)
+    loan_config = LoanConfig(
+        deposit=0,
+        annual_rate=0.0,
+        loan_term_years=30,
+        borrowing_costs=BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
+    )
     mortgage = Mortgage(
         property=property,
         loan=build_loan(property, loan_config),

--- a/backend/app/schemas/cashflow.py
+++ b/backend/app/schemas/cashflow.py
@@ -304,6 +304,7 @@ class CashFlowYearResponse(BaseModel):
         mortgage_interest: Interest portion of mortgage payments
         mortgage_principal: Principal portion of mortgage payments
         property_costs: Ongoing property costs for the year
+        offset_contributions: Cash added to offset account this year
         rent_paid: Annual rent where the investor lives (rentvesting only, 0 for PPOR)
         rental_income: Annual rental income received (rentvesting only, 0 for PPOR)
         tax_saving: Tax benefit from deductions (rentvesting only, 0 for PPOR)
@@ -323,6 +324,7 @@ class CashFlowYearResponse(BaseModel):
     mortgage_interest: float
     mortgage_principal: float
     property_costs: float
+    offset_contributions: float = 0.0
     rent_paid: float = 0.0
     rental_income: float = 0.0
     tax_saving: float = 0.0

--- a/backend/app/services/amortisation.py
+++ b/backend/app/services/amortisation.py
@@ -7,11 +7,14 @@ Provides three functions:
 - build_schedule_result: schedule + chart data (used by amortisation endpoint)
 """
 
+from dataclasses import replace
+
 from app.engine.amortisation import generate_schedule
 from app.models.amortisation import AmortisationSchedule, ScheduleResult, YearChartPoint
 from app.models.loan import Loan, LoanConfig
 from app.models.mortgage import Mortgage
 from app.models.property import Property
+from app.services.upfront_costs import resolve_borrowing_costs
 
 
 def build_loan(property: Property, loan_config: LoanConfig) -> Loan:
@@ -27,21 +30,29 @@ def build_loan(property: Property, loan_config: LoanConfig) -> Loan:
     Returns:
         Loan wrapping the config and its generated amortisation schedule.
     """
-    loan_amount = max(property.purchase_price - loan_config.deposit, 0.0)
-    loan_amount += loan_config.borrowing_costs.total_capitalised
+    # Resolve any None borrowing costs to auto-estimated values before
+    # computing the loan principal, so capitalised costs are included.
+    base_loan = max(property.purchase_price - loan_config.deposit, 0.0)
+    lvr = base_loan / property.purchase_price if property.purchase_price > 0 else 0.0
+    is_investment = not property.is_ppor
+
+    resolved_bc = resolve_borrowing_costs(base_loan, lvr, is_investment, loan_config.borrowing_costs)
+    resolved_config = replace(loan_config, borrowing_costs=resolved_bc)
+
+    loan_amount = base_loan + resolved_bc.total_capitalised
 
     schedule = generate_schedule(
         principal=loan_amount,
-        annual_rate=loan_config.annual_rate,
-        loan_term_years=loan_config.loan_term_years,
-        frequency=loan_config.frequency,
-        offset_balance=loan_config.offset_balance,
-        extra_repayment=loan_config.extra_repayment,
-        rate_changes=loan_config.rate_changes or None,
-        offset_contribution=loan_config.offset_contribution,
+        annual_rate=resolved_config.annual_rate,
+        loan_term_years=resolved_config.loan_term_years,
+        frequency=resolved_config.frequency,
+        offset_balance=resolved_config.offset_balance,
+        extra_repayment=resolved_config.extra_repayment,
+        rate_changes=resolved_config.rate_changes or None,
+        offset_contribution=resolved_config.offset_contribution,
     )
 
-    return Loan(config=loan_config, schedule=schedule)
+    return Loan(config=resolved_config, schedule=schedule)
 
 
 def build_year_chart_point(

--- a/backend/app/services/cashflow.py
+++ b/backend/app/services/cashflow.py
@@ -158,9 +158,17 @@ def _calculate_cashflow_year(
     rent_paid = rentvest.weekly_rent_paid * 52 * (1 + rentvest.annual_rent_paid_growth) ** year if rentvest else 0.0
     tax_saving = tax_deduction_detail.tax_saving if tax_deduction_detail else 0.0
 
+    # Offset contributions are cash outflows (money moved into offset account)
+    if len(schedule_rows) >= 2:
+        offset_contributions = schedule_rows[-1].offset_balance - schedule_rows[0].offset_balance
+    elif len(schedule_rows) == 1:
+        offset_contributions = 0.0
+    else:
+        offset_contributions = 0.0
+
     # Assemble totals
     total_inflows = net_income + rental_income + tax_saving
-    total_outflows = mortgage_repayment + property_costs + rent_paid
+    total_outflows = mortgage_repayment + property_costs + rent_paid + offset_contributions
     net_position = total_inflows - total_outflows
     cumulative_position = previous_cumulative + net_position
     equity = property_value - loan_balance
@@ -173,6 +181,7 @@ def _calculate_cashflow_year(
         mortgage_interest=mortgage_interest,
         mortgage_principal=mortgage_principal,
         property_costs=property_costs,
+        offset_contributions=offset_contributions,
         rent_paid=rent_paid,
         rental_income=rental_income,
         tax_saving=tax_saving,

--- a/backend/app/services/upfront_costs.py
+++ b/backend/app/services/upfront_costs.py
@@ -20,6 +20,42 @@ from app.models.mortgage import Mortgage
 from app.models.property import PurchaseCosts, UpfrontCosts
 
 
+def resolve_borrowing_costs(
+    loan_amount: float,
+    lvr: float,
+    is_investment: bool,
+    borrowing_costs: BorrowingCosts,
+) -> BorrowingCosts:
+    """Resolve None borrowing cost fields to auto-estimated values.
+
+    For each field:
+    - None -> auto-estimated from engine functions
+    - 0.0 -> explicitly zero (e.g. LMI waived)
+    - Any value -> user override, preserved as-is
+
+    Args:
+        loan_amount: Loan principal for LMI estimation.
+        lvr: Loan-to-value ratio for LMI estimation.
+        is_investment: Whether the property is an investment (affects LMI).
+        borrowing_costs: Unresolved borrowing costs (may contain None fields).
+
+    Returns:
+        Fully resolved BorrowingCosts with no None values.
+    """
+    return BorrowingCosts(
+        lmi=borrowing_costs.lmi if borrowing_costs.lmi is not None else estimate_lmi(loan_amount, lvr, is_investment),
+        mortgage_registration_fee=borrowing_costs.mortgage_registration_fee
+        if borrowing_costs.mortgage_registration_fee is not None
+        else calculate_mortgage_registration_fee(),
+        loan_establishment_fee=borrowing_costs.loan_establishment_fee
+        if borrowing_costs.loan_establishment_fee is not None
+        else calculate_loan_establishment_fee(),
+        capitalise_lmi=borrowing_costs.capitalise_lmi,
+        capitalise_mortgage_registration_fee=borrowing_costs.capitalise_mortgage_registration_fee,
+        capitalise_loan_establishment_fee=borrowing_costs.capitalise_loan_establishment_fee,
+    )
+
+
 def build_upfront_cost_estimate(mortgage: Mortgage) -> UpfrontCosts:
     """
     Resolve and estimate all upfront costs for a property purchase.
@@ -56,16 +92,7 @@ def build_upfront_cost_estimate(mortgage: Mortgage) -> UpfrontCosts:
     )
 
     # Resolve borrowing costs — None means auto-estimate
-    src_bc = mortgage.loan.config.borrowing_costs
-    borrowing_costs = BorrowingCosts(
-        lmi=src_bc.lmi if src_bc.lmi is not None else estimate_lmi(loan_amount, lvr, is_investment),
-        mortgage_registration_fee=src_bc.mortgage_registration_fee
-        if src_bc.mortgage_registration_fee is not None
-        else calculate_mortgage_registration_fee(),
-        loan_establishment_fee=src_bc.loan_establishment_fee
-        if src_bc.loan_establishment_fee is not None
-        else calculate_loan_establishment_fee(),
-    )
+    borrowing_costs = resolve_borrowing_costs(loan_amount, lvr, is_investment, mortgage.loan.config.borrowing_costs)
 
     return UpfrontCosts(
         purchase_costs=purchase_costs,

--- a/backend/app/tests/api/test_cashflow.py
+++ b/backend/app/tests/api/test_cashflow.py
@@ -137,6 +137,7 @@ class TestPporEndpointStructure:
             "mortgage_interest",
             "mortgage_principal",
             "property_costs",
+            "offset_contributions",
             "rent_paid",
             "rental_income",
             "tax_saving",

--- a/backend/app/tests/services/test_amortisation.py
+++ b/backend/app/tests/services/test_amortisation.py
@@ -46,7 +46,8 @@ def _make_loan(
         offset_contribution=offset_contribution,
         extra_repayment=extra_repayment,
         rate_changes=rate_changes or [],
-        borrowing_costs=borrowing_costs or BorrowingCosts(),
+        borrowing_costs=borrowing_costs
+        or BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
     )
 
 
@@ -378,10 +379,12 @@ class TestBuildLoan:
         loan = build_loan(_make_property(), _make_loan())
         assert isinstance(loan, Loan)
 
-    def test_config_preserved(self):
+    def test_config_rate_and_term_preserved(self):
         lc = _make_loan(deposit=200_000, annual_rate=0.05)
         loan = build_loan(_make_property(), lc)
-        assert loan.config is lc
+        assert loan.config.deposit == lc.deposit
+        assert loan.config.annual_rate == lc.annual_rate
+        assert loan.config.loan_term_years == lc.loan_term_years
 
     def test_schedule_generated(self):
         loan = build_loan(_make_property(), _make_loan())
@@ -397,7 +400,7 @@ class TestBuildLoan:
         assert loan.schedule.rows[0].opening_balance == pytest.approx(400_000)
 
     def test_capitalised_costs_added_to_principal(self):
-        bc = BorrowingCosts(lmi=20_000)
+        bc = BorrowingCosts(lmi=20_000, mortgage_registration_fee=0.0, loan_establishment_fee=0.0)
         loan = build_loan(
             _make_property(purchase_price=500_000),
             _make_loan(deposit=100_000, borrowing_costs=bc),

--- a/backend/app/tests/services/test_cashflow.py
+++ b/backend/app/tests/services/test_cashflow.py
@@ -81,7 +81,8 @@ def _make_loan(deposit=100_000, annual_rate=0.06, loan_term_years=30, borrowing_
         deposit=deposit,
         annual_rate=annual_rate,
         loan_term_years=loan_term_years,
-        borrowing_costs=borrowing_costs or BorrowingCosts(),
+        borrowing_costs=borrowing_costs
+        or BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
     )
 
 
@@ -196,6 +197,7 @@ def _make_cashflow_year(
     mortgage_interest=24_000,
     mortgage_principal=6_000,
     property_costs=10_000,
+    offset_contributions=0,
     rent_paid=0,
     rental_income=0,
     tax_saving=0,
@@ -205,7 +207,7 @@ def _make_cashflow_year(
     previous_cumulative=0,
 ) -> CashFlowYear:
     total_inflows = net_income + rental_income + tax_saving
-    total_outflows = mortgage_repayment + property_costs + rent_paid
+    total_outflows = mortgage_repayment + property_costs + offset_contributions + rent_paid
     net_position = total_inflows - total_outflows
     cumulative_position = previous_cumulative + net_position
     equity = property_value - loan_balance
@@ -217,6 +219,7 @@ def _make_cashflow_year(
         mortgage_interest=mortgage_interest,
         mortgage_principal=mortgage_principal,
         property_costs=property_costs,
+        offset_contributions=offset_contributions,
         rent_paid=rent_paid,
         rental_income=rental_income,
         tax_saving=tax_saving,

--- a/backend/app/tests/services/test_comparison.py
+++ b/backend/app/tests/services/test_comparison.py
@@ -73,7 +73,7 @@ def _make_loan(deposit=100_000, annual_rate=0.06, loan_term_years=30) -> LoanCon
         deposit=deposit,
         annual_rate=annual_rate,
         loan_term_years=loan_term_years,
-        borrowing_costs=BorrowingCosts(),
+        borrowing_costs=BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
     )
 
 

--- a/backend/app/tests/services/test_ongoing_costs.py
+++ b/backend/app/tests/services/test_ongoing_costs.py
@@ -6,7 +6,7 @@ from datetime import date
 
 import pytest
 
-from app.models.loan import LoanConfig
+from app.models.loan import BorrowingCosts, LoanConfig
 from app.models.mortgage import Mortgage
 from app.models.property import OngoingCostsConfig, Property, RentalConfig
 from app.services.amortisation import build_loan
@@ -58,7 +58,12 @@ def _make_ongoing_costs(
 
 def _make_mortgage(property=None, ongoing_costs=None, projection_years=10) -> Mortgage:
     p = property or _make_property()
-    lc = LoanConfig(deposit=0, annual_rate=0.0, loan_term_years=30)
+    lc = LoanConfig(
+        deposit=0,
+        annual_rate=0.0,
+        loan_term_years=30,
+        borrowing_costs=BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
+    )
     return Mortgage(
         property=p,
         loan=build_loan(p, lc),

--- a/backend/app/tests/services/test_tax_deductions.py
+++ b/backend/app/tests/services/test_tax_deductions.py
@@ -103,7 +103,8 @@ def _make_loan(loan_term_years=30, borrowing_costs=None) -> LoanConfig:
         deposit=100_000,
         annual_rate=0.06,
         loan_term_years=loan_term_years,
-        borrowing_costs=borrowing_costs or BorrowingCosts(),
+        borrowing_costs=borrowing_costs
+        or BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
     )
 
 

--- a/backend/app/tests/services/test_upfront_costs.py
+++ b/backend/app/tests/services/test_upfront_costs.py
@@ -32,7 +32,8 @@ def _make_loan(deposit=100_000, borrowing_costs=None) -> LoanConfig:
         deposit=deposit,
         annual_rate=0.06,
         loan_term_years=30,
-        borrowing_costs=borrowing_costs or BorrowingCosts(),
+        borrowing_costs=borrowing_costs
+        or BorrowingCosts(lmi=0.0, mortgage_registration_fee=0.0, loan_establishment_fee=0.0),
     )
 
 
@@ -80,7 +81,7 @@ class TestAutoEstimation:
 
     def test_lmi_auto_estimated_high_lvr(self):
         """90% LVR should auto-estimate LMI > 0."""
-        result = _build(loan=_make_loan(deposit=50_000))
+        result = _build(loan=_make_loan(deposit=50_000, borrowing_costs=BorrowingCosts()))
         assert result.borrowing_costs.lmi is not None
         assert result.borrowing_costs.lmi > 0
 
@@ -90,12 +91,12 @@ class TestAutoEstimation:
         assert result.borrowing_costs.lmi == 0.0
 
     def test_mortgage_registration_auto_estimated(self):
-        result = _build()
+        result = _build(loan=_make_loan(borrowing_costs=BorrowingCosts()))
         assert result.borrowing_costs.mortgage_registration_fee is not None
         assert result.borrowing_costs.mortgage_registration_fee > 0
 
     def test_loan_establishment_auto_estimated(self):
-        result = _build()
+        result = _build(loan=_make_loan(borrowing_costs=BorrowingCosts()))
         assert result.borrowing_costs.loan_establishment_fee is not None
         assert result.borrowing_costs.loan_establishment_fee > 0
 
@@ -188,18 +189,18 @@ class TestLmi:
     def test_lmi_90_lvr(self):
         result = _build(
             property=_make_property(is_ppor=True),
-            loan=_make_loan(deposit=50_000),
+            loan=_make_loan(deposit=50_000, borrowing_costs=BorrowingCosts()),
         )
         assert result.borrowing_costs.lmi == pytest.approx(450_000 * 0.02, abs=1)
 
     def test_lmi_investment_multiplier(self):
         ppor = _build(
             property=_make_property(is_ppor=True),
-            loan=_make_loan(deposit=50_000),
+            loan=_make_loan(deposit=50_000, borrowing_costs=BorrowingCosts()),
         )
         inv = _build(
             property=_make_property(is_ppor=False),
-            loan=_make_loan(deposit=50_000),
+            loan=_make_loan(deposit=50_000, borrowing_costs=BorrowingCosts()),
         )
         assert inv.borrowing_costs.lmi == pytest.approx(ppor.borrowing_costs.lmi * 1.15, abs=1)
 
@@ -231,7 +232,7 @@ class TestTotals:
     def test_investment_higher_total(self):
         inv = _build(
             property=_make_property(is_ppor=False),
-            loan=_make_loan(deposit=50_000),
+            loan=_make_loan(deposit=50_000, borrowing_costs=BorrowingCosts()),
         )
         ppor = _build(
             property=_make_property(is_ppor=True),


### PR DESCRIPTION
## Summary
  - **Bug 1 fix**: Offset contributions now included in `total_outflows` — previously offset account growth was counted as wealth without deducting the cash going in, creating phantom net wealth
  - **Bug 2 fix**: Auto-estimated borrowing costs (LMI, registration, establishment fees) now correctly capitalised into loan principal — previously `build_loan` ran before `None` values were resolved, so `total_capitalised` was always `0.0`
  - Extracted `resolve_borrowing_costs()` from upfront costs service for reuse in `build_loan`
  - Added `offset_contributions` field to `CashFlowYear` model and API response schema
  - Routers that create dummy loans (amortisation, ongoing costs) now explicitly zero borrowing costs

  ## Test plan
  - [ ] All 1064 tests pass
  - [ ] Existing tests updated for new `offset_contributions` field and resolved borrowing costs
  - [ ] Verify: POST high-LVR scenario with `None` borrowing costs → opening balance includes auto-estimated LMI
  - [ ] Verify: Projection with offset contributions → `total_outflows` includes offset growth

  Closes #50