### PR TITLE
Feat/auth router current user

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -62,7 +62,12 @@
       "Bash(curl *)",
       "Bash(echo \"exit: $?\")",
       "Bash(git *)",
-      "Bash(npm uninstall *)"
+      "Bash(npm uninstall *)",
+      "Bash(gh pr *)",
+      "Bash(/c/Program Files/GitHub CLI/gh.exe pr *)",
+      "Bash(where gh *)",
+      "Read(//c/Program Files \\(x86\\)/**)",
+      "Read(//c/Users/Jordan/AppData/Local/Programs/**)"
     ]
   }
 }

--- a/platform/src/app.module.ts
+++ b/platform/src/app.module.ts
@@ -6,11 +6,7 @@ import { AuthModule } from './auth/auth.module';
 import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
-  imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
-    PrismaModule,
-    AuthModule,
-  ],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/platform/src/auth/auth.controller.ts
+++ b/platform/src/auth/auth.controller.ts
@@ -1,6 +1,16 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 
+import { AuthGuard } from './auth.guard';
 import { AuthService } from './auth.service';
+import { CurrentUser } from './current-user.decorator';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -26,5 +36,13 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   refresh(@Body() dto: RefreshTokenDto): Promise<TokenResponseDto> {
     return this.authService.refreshToken(dto.refreshToken);
+  }
+
+  @Get('me')
+  @UseGuards(AuthGuard)
+  me(
+    @CurrentUser() user: { userId: string; email: string },
+  ): { userId: string; email: string } {
+    return user;
   }
 }

--- a/platform/src/auth/auth.controller.ts
+++ b/platform/src/auth/auth.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { RegisterDto } from './dto/register.dto';
+import { TokenResponseDto } from './dto/token-response.dto';
+import { UserResponseDto } from './dto/user-response.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  register(@Body() dto: RegisterDto): Promise<UserResponseDto> {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  login(@Body() dto: LoginDto): Promise<TokenResponseDto> {
+    return this.authService.login(dto);
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  refresh(@Body() dto: RefreshTokenDto): Promise<TokenResponseDto> {
+    return this.authService.refreshToken(dto.refreshToken);
+  }
+}

--- a/platform/src/auth/auth.guard.ts
+++ b/platform/src/auth/auth.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { AuthService } from './auth.service';
+
+export interface AuthenticatedRequest extends Request {
+  user: { userId: string; email: string };
+}
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const token = this.extractBearerToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Missing bearer token');
+    }
+
+    request.user = await this.authService.validateToken(token);
+    return true;
+  }
+
+  private extractBearerToken(request: Request): string | null {
+    const header = request.headers.authorization;
+    if (!header) return null;
+    const [scheme, value] = header.split(' ');
+    return scheme === 'Bearer' && value ? value : null;
+  }
+}

--- a/platform/src/auth/auth.module.ts
+++ b/platform/src/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import type { StringValue } from 'ms';
 
+import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 
 @Module({
@@ -20,6 +21,7 @@ import { AuthService } from './auth.service';
       }),
     }),
   ],
+  controllers: [AuthController],
   providers: [AuthService],
   exports: [AuthService],
 })

--- a/platform/src/auth/current-user.decorator.ts
+++ b/platform/src/auth/current-user.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+import type { AuthenticatedRequest } from './auth.guard';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, context: ExecutionContext) => {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    return request.user;
+  },
+);

--- a/platform/src/auth/dto/refresh-token.dto.ts
+++ b/platform/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsString()
+  refreshToken!: string;
+}

--- a/platform/src/main.ts
+++ b/platform/src/main.ts
@@ -22,4 +22,4 @@ async function bootstrap() {
 
   await app.listen(process.env.PORT ?? 3001);
 }
-bootstrap();
+void bootstrap();

--- a/platform/src/main.ts
+++ b/platform/src/main.ts
@@ -10,6 +10,7 @@ async function bootstrap() {
   app.enableCors({
     origin: process.env.FRONTEND_ORIGIN ?? 'http://localhost:3000',
     credentials: true,
+    allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary
  - Adds `AuthGuard` (`CanActivate`) that validates Bearer tokens and attaches `{ userId, email }` to the request.
  - Adds `@CurrentUser()` param decorator for clean access to the authenticated user.
  - Adds guarded `GET /auth/me` returning the current user's id and email.
  - Allows the `Authorization` header through CORS preflight.

  Closes #62