### PR TITLE
revert: undo layout alignment regression from 08fa48d

### DIFF
--- a/frontend/src/components/cashflow/CashflowDashboard.tsx
+++ b/frontend/src/components/cashflow/CashflowDashboard.tsx
@@ -59,7 +59,7 @@ export default function CashflowDashboard({
   else if (vm === "deductions") panelProp.deductionsPanel = "unified";
 
   return (
-    <main className="text-foreground flex flex-col gap-6">
+    <main className="text-foreground max-w-[1400px] mx-auto px-4 py-6 flex flex-col gap-6">
       {/* ── Chart + Tabs ── */}
       <div className="flex items-stretch">
         <div className="relative flex-1 min-w-0 flex flex-col">

--- a/frontend/src/components/cashflow/CashflowView.tsx
+++ b/frontend/src/components/cashflow/CashflowView.tsx
@@ -152,7 +152,7 @@ export default function CashflowCalculator() {
       )}
 
       {s.error && (
-        <div className="mb-4">
+        <div className="max-w-[1400px] mx-auto px-4 pt-6">
           <div className="rounded-lg border border-red-400/20 bg-red-400/5 px-4 py-3 text-[14px] text-red-400/80">
             {s.error}
           </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -6,22 +6,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen" style={{ background: "var(--color-background)" }}>
       <Sidebar />
       <main
-        className="flex-1 min-w-0 flex flex-col"
+        className="flex-1 min-w-0 relative"
         style={{ background: "var(--color-background)" }}
       >
+        <GlobalsTray />
         <div
-          className="flex justify-end items-center shrink-0"
-          style={{
-            paddingLeft: "var(--layout-page-padding-x)",
-            paddingRight: "var(--layout-page-padding-x)",
-            paddingTop: "20px",
-            paddingBottom: "12px",
-          }}
-        >
-          <GlobalsTray />
-        </div>
-        <div
-          className="mx-auto w-full"
+          className="mx-auto"
           style={{
             maxWidth: "var(--layout-content-max)",
             paddingLeft: "var(--layout-page-padding-x)",

--- a/frontend/src/components/layout/GlobalsTray.tsx
+++ b/frontend/src/components/layout/GlobalsTray.tsx
@@ -4,7 +4,7 @@ import ThemeToggle from "./ThemeToggle";
 
 export default function GlobalsTray() {
   return (
-    <div className="flex items-center gap-1">
+    <div className="absolute top-6 right-6 flex gap-1 z-10">
       <ThemeToggle />
     </div>
   );

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -6,7 +6,7 @@ interface PageHeaderProps {
 
 export default function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
   return (
-    <div className="flex items-start justify-between gap-4 mb-8">
+    <div className="flex items-start justify-between gap-4 mb-8 pr-16">
       <div className="min-w-0">
         <h1
           className="text-[30px] font-semibold leading-[1.1] tracking-[-0.02em]"


### PR DESCRIPTION
## Summary
  - Revert `08fa48d` ("fix(frontend): align page titles with content below") — the changes it introduced broke visual alignment and layout spacing across tool pages.
  - Returns the shell + view layout to the `c4e94e2` state, which was confirmed working.                                                                                                                                                                                                                                     
  ## What gets reverted                                                                                                                                                                                                                                                                                                        - `AppShell.tsx` — top bar goes back to absolute `top-6 right-6` positioning
  - `GlobalsTray.tsx` — restores absolute positioning wrapper
  - `PageHeader.tsx` — `pr-16` reinstated to keep title clear of the tray
  - `CashflowDashboard.tsx` — restores `max-w-[1400px] mx-auto px-4 py-6` on `<main>` (the `py-6` and 1400px cap were intentional layout, not chrome)
  - `CashflowView.tsx` — restores `max-w-[1400px] mx-auto px-4 pt-6` wrapper on the error banner