### PR TITLE
refactor(frontend): replace PageHeader pr-16 magic number with layout…

### DIFF
--- a/frontend/docs/TOKENS.md
+++ b/frontend/docs/TOKENS.md
@@ -61,3 +61,4 @@ Utility classes in `globals.css`:
 | `--layout-page-padding-y` | `32px` | Vertical page padding |
 | `--layout-nav-item-height` | `36px` | Sidebar nav item row height |
 | `--layout-global-btn-size` | `34px` | Globals tray icon button size |
+| `--layout-header-actions-reserve` | `64px` | Right-padding reservation on page headers to avoid overlap with the floating globals tray. Update when the tray's width changes. |

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -68,6 +68,8 @@
   --layout-page-padding-y: 32px;
   --layout-nav-item-height: 36px;
   --layout-global-btn-size: 34px;
+  /* Reservation on the right of page headers to keep clear of the globals tray */
+  --layout-header-actions-reserve: 64px;
 }
 
 

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -6,7 +6,10 @@ interface PageHeaderProps {
 
 export default function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
   return (
-    <div className="flex items-start justify-between gap-4 mb-8 pr-16">
+    <div
+      className="flex items-start justify-between gap-4 mb-8"
+      style={{ paddingRight: "var(--layout-header-actions-reserve)" }}
+    >
       <div className="min-w-0">
         <h1
           className="text-[30px] font-semibold leading-[1.1] tracking-[-0.02em]"


### PR DESCRIPTION
## Summary
  - Replace the `pr-16` magic number on `<PageHeader>` with a new `--layout-header-actions-reserve: 64px` token.
  - No visual change — same 64px reservation, just named.

  ## Why
  `pr-16` encoded an implicit dependency on `<GlobalsTray>`'s position and width. If the tray ever grows (second global action, bigger button), the title overlaps the toggle silently. Promoting it to a token makes the relationship explicit and updatable in one place.

  ## Files
  - `frontend/src/app/globals.css` — add `--layout-header-actions-reserve` to the Layout section
  - `frontend/src/components/layout/PageHeader.tsx` — swap `pr-16` class for inline `paddingRight: var(--layout-header-actions-reserve)`
  - `frontend/docs/TOKENS.md` — document the new token