### PR TITLE
Feat/property model

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -77,7 +77,8 @@
       "Bash(tee /dev/stderr)",
       "PowerShell(gh issue list --milestone 6 --repo jordanlbf/MortgageModeler --state all --json number,title,state,labels --limit 50)",
       "PowerShell(gh issue *)",
-      "Bash(npx --prefix frontend tsc -p frontend --noEmit)"
+      "Bash(npx --prefix frontend tsc -p frontend --noEmit)",
+      "PowerShell(Set-Location D:\\\\MortgageModeler\\\\platform; $env:PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION = \"yes\"; npx prisma migrate reset --force)"
     ]
   }
 }

--- a/platform/prisma/migrations/20260503014834_add_property_model/migration.sql
+++ b/platform/prisma/migrations/20260503014834_add_property_model/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "PropertyUse" AS ENUM ('INVESTMENT', 'PPOR');
+
+-- CreateEnum
+CREATE TYPE "PurchaseMode" AS ENUM ('NEW', 'EXISTING');
+
+-- CreateTable
+CREATE TABLE "properties" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "address" TEXT,
+    "suburb" TEXT,
+    "propertyUse" "PropertyUse" NOT NULL,
+    "purchaseMode" "PurchaseMode" NOT NULL,
+    "purchasePrice" DECIMAL(14,2) NOT NULL,
+    "purchaseDate" DATE NOT NULL,
+    "inputs" JSONB NOT NULL,
+    "inputsVersion" INTEGER NOT NULL DEFAULT 1,
+    "cashflowResult" JSONB,
+    "cashflowVersion" INTEGER,
+    "annualCashflow" DECIMAL(14,2),
+    "currentEquity" DECIMAL(14,2),
+    "computedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "properties_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "properties_userId_updatedAt_idx" ON "properties"("userId", "updatedAt");
+
+-- AddForeignKey
+ALTER TABLE "properties" ADD CONSTRAINT "properties_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/platform/prisma/schema.prisma
+++ b/platform/prisma/schema.prisma
@@ -13,11 +13,46 @@ datasource db {
 }
 
 model User {
-  id             String   @id @default(cuid())
-  email          String   @unique
+  id             String     @id @default(cuid())
+  email          String     @unique
   hashedPassword String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+  properties     Property[]
 
   @@map("users")
+}
+
+enum PropertyUse {
+  INVESTMENT
+  PPOR
+}
+
+enum PurchaseMode {
+  NEW
+  EXISTING
+}
+
+model Property {
+  id              String       @id @default(cuid())
+  userId          String
+  user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  address         String?
+  suburb          String?
+  propertyUse     PropertyUse
+  purchaseMode    PurchaseMode
+  purchasePrice   Decimal      @db.Decimal(14, 2)
+  purchaseDate    DateTime     @db.Date
+  inputs          Json
+  inputsVersion   Int          @default(1)
+  cashflowResult  Json?
+  cashflowVersion Int?
+  annualCashflow  Decimal?     @db.Decimal(14, 2)
+  currentEquity   Decimal?     @db.Decimal(14, 2)
+  computedAt      DateTime?
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
+
+  @@index([userId, updatedAt])
+  @@map("properties")
 }

--- a/platform/src/properties/dto/create-property.dto.ts
+++ b/platform/src/properties/dto/create-property.dto.ts
@@ -1,0 +1,42 @@
+import { PropertyUse, PurchaseMode } from '@prisma/client';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class CreatePropertyDto {
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  suburb?: string;
+
+  @IsEnum(PropertyUse)
+  propertyUse!: PropertyUse;
+
+  @IsEnum(PurchaseMode)
+  purchaseMode!: PurchaseMode;
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  purchasePrice!: number;
+
+  @IsDateString()
+  purchaseDate!: string;
+
+  @IsObject()
+  inputs!: Record<string, unknown>;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  inputsVersion?: number;
+}

--- a/platform/src/properties/dto/property-detail.dto.ts
+++ b/platform/src/properties/dto/property-detail.dto.ts
@@ -1,0 +1,21 @@
+import { Prisma, PropertyUse, PurchaseMode } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export class PropertyDetailDto {
+  id!: string;
+  address!: string | null;
+  suburb!: string | null;
+  propertyUse!: PropertyUse;
+  purchaseMode!: PurchaseMode;
+  purchasePrice!: Decimal;
+  purchaseDate!: Date;
+  inputs!: Prisma.JsonValue;
+  inputsVersion!: number;
+  cashflowResult!: Prisma.JsonValue | null;
+  cashflowVersion!: number | null;
+  annualCashflow!: Decimal | null;
+  currentEquity!: Decimal | null;
+  computedAt!: Date | null;
+  createdAt!: Date;
+  updatedAt!: Date;
+}

--- a/platform/src/properties/dto/property-summary.dto.ts
+++ b/platform/src/properties/dto/property-summary.dto.ts
@@ -1,0 +1,13 @@
+import { PropertyUse } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export class PropertySummaryDto {
+  id!: string;
+  address!: string | null;
+  suburb!: string | null;
+  propertyUse!: PropertyUse;
+  purchasePrice!: Decimal;
+  annualCashflow!: Decimal | null;
+  currentEquity!: Decimal | null;
+  updatedAt!: Date;
+}

--- a/platform/src/properties/dto/update-property.dto.ts
+++ b/platform/src/properties/dto/update-property.dto.ts
@@ -1,0 +1,47 @@
+import { PropertyUse, PurchaseMode } from '@prisma/client';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class UpdatePropertyDto {
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  suburb?: string;
+
+  @IsOptional()
+  @IsEnum(PropertyUse)
+  propertyUse?: PropertyUse;
+
+  @IsOptional()
+  @IsEnum(PurchaseMode)
+  purchaseMode?: PurchaseMode;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  purchasePrice?: number;
+
+  @IsOptional()
+  @IsDateString()
+  purchaseDate?: string;
+
+  @IsOptional()
+  @IsObject()
+  inputs?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  inputsVersion?: number;
+}


### PR DESCRIPTION
## Summary
  - Adds `Property` Prisma model with versioned `inputs`/`cashflowResult` JSON blobs, denormalised `annualCashflow`/`currentEquity` for list-view sorting, and composite index on `(userId, updatedAt)`.
  - `address` is nullable to support hypothetical/scenario modelling without a specific listing.
  - Adds four DTOs in `src/properties/dto/`: create, update (input), summary, detail (response).
  - No controller/service — deferred to #64.

  ## Test plan
  - [ ] `npx prisma migrate reset --force` succeeds and re-applies cleanly
  - [ ] `properties` table appears in Prisma Studio with all columns and the composite index
  - [ ] `npx tsc --noEmit` passes on the platform project

  Closes #63